### PR TITLE
fix: update limacharlie detection to use rphcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ EDR Detections Currently Available
 - Sophos EDR
 - Fortinet EDR
 - MalwareBytes EDR
-- LimaCharlie EDR
+- LimaCharlie Agent
 
 More to be added soon.
 

--- a/pkg/edrRecon/edrdata.go
+++ b/pkg/edrRecon/edrdata.go
@@ -869,6 +869,10 @@ var EdrList = []string{
 	"Notifier.exe",
 	"qualys",
 	"qualysagent.exe",
+	"rphcp.exe",
+	"lc_sensor.exe",
+	"refractionPOINT HCP",
+	"LimaCharlie",
 }
 
 var ReconList = []string{

--- a/pkg/scanners/scan_limacharlie.go
+++ b/pkg/scanners/scan_limacharlie.go
@@ -5,7 +5,7 @@ import "github.com/FourCoreLabs/EDRHunt/pkg/resources"
 type LimacharlieDetection struct{}
 
 func (w *LimacharlieDetection) Name() string {
-	return "Limacharlie EDR"
+	return "Limacharlie Agent"
 }
 
 func (w *LimacharlieDetection) Type() resources.EDRType {
@@ -13,6 +13,7 @@ func (w *LimacharlieDetection) Type() resources.EDRType {
 }
 
 var LimacharlieHeuristic = []string{
+	"rphcp.exe",
 	"lc_sensor.exe",
 	"refractionPOINT HCP",
 	"LimaCharlie",


### PR DESCRIPTION
- Update limacharlie detection to use process name as well
- Add limacharlie strings to root edrdata.